### PR TITLE
fix: Update uglifyjs warnings configuration

### DIFF
--- a/src/config/webpack.prod.ts
+++ b/src/config/webpack.prod.ts
@@ -29,8 +29,8 @@ export default ({ paths, sourceMaps }: IWebpackConfig): Configuration => {
       minimizer: [
         new UglifyJsPlugin({
           uglifyOptions: {
+            warnings: false,
             compress: {
-              warnings: false,
               // Disabled because of an issue with Uglify breaking seemingly valid code:
               // https://github.com/facebook/create-react-app/issues/2376
               // Pending further investigation:


### PR DESCRIPTION
`html-webpack-plugin` was bumped from 4.0.0-beta.2 to 4.0.0-beta.8 and as a result `uglifyjs` got upgraded from `3.4.0` to `3.6.0`: https://github.com/heydoctor/web-app/compare/develop#diff-8ee2343978836a779dc9f8d6b794c3b2R11572

this updates the configuration to appease uglify's new configuration expectations