### PR TITLE
fix: Add core-js and specify version in webpack config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3107,6 +3107,12 @@
         "@types/webpack": "*"
       }
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -3117,6 +3123,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
+      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
     },
     "@types/relateurl": {
       "version": "0.2.28",
@@ -5794,6 +5810,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "core-js": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.3.tgz",
+      "integrity": "sha512-DOO9b18YHR+Wk5kJ/c5YFbXuUETreD4TrvXb6edzqZE3aAEd0eJIAWghZ9HttMuiON8SVCnU3fqA4rPxRDD1HQ=="
+    },
     "core-js-compat": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.2.tgz",
@@ -6174,6 +6195,12 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bfj": "^7.0.1",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "chalk": "^3.0.0",
+    "core-js": "3.6.3",
     "css-loader": "^3.2.0",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",

--- a/src/config/webpack.base.ts
+++ b/src/config/webpack.base.ts
@@ -76,7 +76,7 @@ export default ({ mode, paths, env, sourceMaps }: IWebpackConfig): Configuration
 
   return {
     resolve: {
-      extensions: ['.ts', '.tsx', '.js', '.jsx']
+      extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
     output: {
       // Point sourcemap entries to original disk location (format as URL on Windows)
@@ -151,6 +151,7 @@ export default ({ mode, paths, env, sourceMaps }: IWebpackConfig): Configuration
                         {
                           useBuiltIns: 'entry',
                           modules: false,
+                          corejs: '3.6.3',
                         },
                       ],
                       ['@babel/react', { development: !isProd, useBuiltIns: true }],


### PR DESCRIPTION
### 📜 Summary 
Adds `core-js@3` package and specifies the version in the webpack config to get rid of a very annoying `useBuiltIns option without declaring a core-js` warning message. 