### PR TITLE
fix: Allow Webpack to transpile node modules to ES5 

### DIFF
--- a/src/config/webpack.base.ts
+++ b/src/config/webpack.base.ts
@@ -132,7 +132,7 @@ export default ({ mode, paths, env, sourceMaps }: IWebpackConfig): Configuration
             {
               test: /(js|jsx|ts|tsx)$/,
               // include: paths.srcPaths,
-              exclude: /node_modules/,
+              // exclude: /node_modules/,
               use: [
                 // This loader parallelizes code compilation, it is optional but
                 // improves compile time on larger projects

--- a/src/config/webpack.base.ts
+++ b/src/config/webpack.base.ts
@@ -132,7 +132,7 @@ export default ({ mode, paths, env, sourceMaps }: IWebpackConfig): Configuration
             {
               test: /(js|jsx|ts|tsx)$/,
               // include: paths.srcPaths,
-              // exclude: /node_modules/,
+              exclude: /node_modules\/(?![slate])/,
               use: [
                 // This loader parallelizes code compilation, it is optional but
                 // improves compile time on larger projects


### PR DESCRIPTION
### 📃 Summary
**Problem**
We upgraded slate to its latest version within the emr. This package contains files which contain es6 code. 
UglifyJS does not understand es6 and can not minify it. This causes the build to fail. 
![image](https://user-images.githubusercontent.com/23666138/90175752-bfa1c080-dd5c-11ea-8eb0-7860bf8f4a3b.png)

[PR where the build fails](https://github.com/heydoctor/emr/pull/728/checks?check_run_id=968898066)

**Solution**
We want to use Webpack to transpile our node modules to es5 before attempting to minify. 

### 📸 Screenshots
Files with es6 code
![image](https://user-images.githubusercontent.com/23666138/90175690-a436b580-dd5c-11ea-9b1c-bed0005470f1.png)
	
### 📈 Risk Analysis
- [ ] Does this affect patients?
- [ ] Does this affect clinical?
- [ ] Does this mutate data?
- [ ] Does it touch PHI?
- [ ] Does it touch payments?
- [ ] Does it update Node packages?