### PR TITLE
Revert "fix: Allow Webpack to transpile node modules to ES5 "

### DIFF
--- a/src/config/webpack.base.ts
+++ b/src/config/webpack.base.ts
@@ -132,7 +132,7 @@ export default ({ mode, paths, env, sourceMaps }: IWebpackConfig): Configuration
             {
               test: /(js|jsx|ts|tsx)$/,
               // include: paths.srcPaths,
-              exclude: /node_modules\/(?![slate])/,
+              exclude: /node_modules/,
               use: [
                 // This loader parallelizes code compilation, it is optional but
                 // improves compile time on larger projects


### PR DESCRIPTION
Reverts heydoctor/medpack#33
We have decided to make this change within EMR config instead of here.